### PR TITLE
feat: 基本的なユーザー管理API実装 (Issue #3)

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,17 +1,20 @@
 """User management endpoints."""
 
 from datetime import datetime
-from typing import Union
+from typing import Union, List, Optional, Dict, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
 from app.core.dependencies import get_db, get_current_active_user, get_current_superuser
 from app.models.user import User
-from app.schemas.user import UserCreate, UserResponse
+from app.schemas.user import UserCreate, UserResponse, UserUpdate, PasswordChange
+from app.schemas.common import PaginatedResponse, DeleteResponse
 from app.schemas.error import ErrorResponse
+from app.services.user import UserService
+from app.core.exceptions import BusinessLogicError, NotFound, PermissionDenied
 
 
 router = APIRouter(prefix="/users", tags=["Users"])
@@ -33,28 +36,39 @@ def create_user(
     current_user: User = Depends(get_current_superuser)
 ) -> Union[UserResponse, JSONResponse]:
     """Create a new user (admin only)."""
+    service = UserService(db)
+    
     try:
-        # Create user
-        user = User.create(
-            db,
-            email=user_data.email,
-            password=user_data.password,
-            full_name=user_data.full_name,
-            is_active=user_data.is_active
+        user = service.create_basic_user(
+            user_data,
+            created_by=current_user.id
         )
-        db.commit()
-        db.refresh(user)
         
         return UserResponse.model_validate(user)
         
+    except BusinessLogicError as e:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=ErrorResponse(
+                detail=str(e),
+                code="USER_EXISTS"
+            ).model_dump()
+        )
+    except NotFound as e:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=ErrorResponse(
+                detail=str(e),
+                code="NOT_FOUND"
+            ).model_dump()
+        )
     except IntegrityError:
         db.rollback()
         return JSONResponse(
             status_code=status.HTTP_409_CONFLICT,
             content=ErrorResponse(
                 detail="User with this email already exists",
-                code="USER001",
-                timestamp=datetime.utcnow()
+                code="USER_EXISTS"
             ).model_dump()
         )
 
@@ -71,3 +85,260 @@ def get_current_user_info(
 ) -> UserResponse:
     """Get current user information."""
     return UserResponse.model_validate(current_user)
+
+
+@router.get(
+    "",
+    response_model=PaginatedResponse[UserResponse],
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+    }
+)
+def list_users(
+    skip: int = Query(0, ge=0, description="Number of items to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Number of items to return"),
+    search: Optional[str] = Query(None, description="Search query"),
+    active_only: bool = Query(True, description="Only return active users"),
+    organization_id: Optional[int] = Query(None, description="Filter by organization"),
+    department_id: Optional[int] = Query(None, description="Filter by department"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+) -> PaginatedResponse[UserResponse]:
+    """List users with pagination and filtering."""
+    service = UserService(db)
+    
+    # Only superusers can see all users
+    if not current_user.is_superuser:
+        # Regular users can only see users in their organizations
+        user_orgs = [o.id for o in current_user.get_organizations()]
+        if organization_id and organization_id not in user_orgs:
+            # Return empty if trying to filter by org they don't belong to
+            return PaginatedResponse(items=[], total=0, skip=skip, limit=limit)
+        # If no org filter, we'll filter by their orgs in the service
+        if not organization_id and user_orgs:
+            organization_id = user_orgs[0]  # Default to first org
+    
+    users, total = service.list_users(
+        skip=skip,
+        limit=limit,
+        active_only=active_only,
+        organization_id=organization_id,
+        department_id=department_id,
+        search=search
+    )
+    
+    return PaginatedResponse(
+        items=[UserResponse.model_validate(user) for user in users],
+        total=total,
+        skip=skip,
+        limit=limit
+    )
+
+
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "User not found"},
+    }
+)
+def get_user(
+    user_id: int = Path(..., description="User ID"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+) -> Union[UserResponse, JSONResponse]:
+    """Get user details."""
+    service = UserService(db)
+    user = service.get_user(user_id)
+    
+    if not user:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=ErrorResponse(
+                detail="User not found",
+                code="USER_NOT_FOUND"
+            ).model_dump()
+        )
+    
+    # Check permissions
+    if not current_user.can_access_user(user):
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponse(
+                detail="Insufficient permissions to access this user",
+                code="PERMISSION_DENIED"
+            ).model_dump()
+        )
+    
+    return UserResponse.model_validate(user)
+
+
+@router.put(
+    "/{user_id}",
+    response_model=UserResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "User not found"},
+    }
+)
+def update_user(
+    user_id: int = Path(..., description="User ID"),
+    user_data: UserUpdate = ...,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+) -> Union[UserResponse, JSONResponse]:
+    """Update user information."""
+    service = UserService(db)
+    
+    # Check if user exists
+    user = service.get_user(user_id)
+    if not user:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=ErrorResponse(
+                detail="User not found",
+                code="USER_NOT_FOUND"
+            ).model_dump()
+        )
+    
+    # Check permissions (users can update themselves, admins can update anyone)
+    if user_id != current_user.id and not current_user.is_superuser:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponse(
+                detail="Insufficient permissions to update this user",
+                code="PERMISSION_DENIED"
+            ).model_dump()
+        )
+    
+    try:
+        updated_user = service.update_basic_user(
+            user_id,
+            user_data,
+            updated_by=current_user.id
+        )
+        
+        if not updated_user:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content=ErrorResponse(
+                    detail="User not found",
+                    code="USER_NOT_FOUND"
+                ).model_dump()
+            )
+            
+        return UserResponse.model_validate(updated_user)
+        
+    except NotFound as e:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=ErrorResponse(
+                detail=str(e),
+                code="NOT_FOUND"
+            ).model_dump()
+        )
+
+
+@router.delete(
+    "/{user_id}",
+    response_model=DeleteResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "User not found"},
+    }
+)
+def delete_user(
+    user_id: int = Path(..., description="User ID"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_superuser)  # Only superusers can delete
+) -> Union[DeleteResponse, JSONResponse]:
+    """Delete (soft delete) a user."""
+    service = UserService(db)
+    
+    try:
+        success = service.delete_user(user_id, deleted_by=current_user.id)
+        
+        if not success:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content=ErrorResponse(
+                    detail="User not found",
+                    code="USER_NOT_FOUND"
+                ).model_dump()
+            )
+            
+        return DeleteResponse(
+            success=True,
+            message="User deleted successfully",
+            id=user_id
+        )
+        
+    except PermissionDenied as e:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponse(
+                detail=str(e),
+                code="PERMISSION_DENIED"
+            ).model_dump()
+        )
+
+
+@router.put(
+    "/{user_id}/password",
+    response_model=None,
+    responses={
+        200: {"description": "Password changed successfully"},
+        400: {"model": ErrorResponse, "description": "Invalid password"},
+        401: {"model": ErrorResponse, "description": "Not authenticated"},
+        403: {"model": ErrorResponse, "description": "Forbidden"},
+        404: {"model": ErrorResponse, "description": "User not found"},
+    }
+)
+def change_password(
+    user_id: int = Path(..., description="User ID"),
+    password_data: PasswordChange = ...,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+) -> Union[Dict[str, Any], JSONResponse]:
+    """Change user password."""
+    # Users can only change their own password
+    if user_id != current_user.id:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=ErrorResponse(
+                detail="You can only change your own password",
+                code="PERMISSION_DENIED"
+            ).model_dump()
+        )
+    
+    service = UserService(db)
+    
+    try:
+        service.change_user_password(
+            user_id,
+            password_data.current_password,
+            password_data.new_password
+        )
+        
+        return {"message": "Password changed successfully"}
+        
+    except NotFound as e:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content=ErrorResponse(
+                detail=str(e),
+                code="USER_NOT_FOUND"
+            ).model_dump()
+        )
+    except BusinessLogicError as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=ErrorResponse(
+                detail=str(e),
+                code="INVALID_PASSWORD"
+            ).model_dump()
+        )

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -12,7 +12,7 @@ from app.services.auth import AuthService
 
 
 # Security scheme
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -25,10 +25,18 @@ def get_db() -> Generator[Session, None, None]:
 
 
 def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
     db: Session = Depends(get_db)
 ) -> User:
     """Get current authenticated user."""
+    # Check if credentials exist
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    
     # Extract token
     token = credentials.credentials
     

--- a/backend/app/schemas/error.py
+++ b/backend/app/schemas/error.py
@@ -11,4 +11,3 @@ class ErrorResponse(BaseModel):
     
     detail: str = Field(..., description="Error detail message")
     code: str = Field(..., description="Error code")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Error timestamp")

--- a/backend/tests/integration/api/v1/test_users.py
+++ b/backend/tests/integration/api/v1/test_users.py
@@ -1,0 +1,375 @@
+"""Integration tests for User API endpoints."""
+
+import pytest
+from typing import Dict, Any
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.models.organization import Organization
+from app.models.department import Department
+from tests.conftest import create_auth_headers
+
+
+class TestUserAPI:
+    """Test cases for User API endpoints."""
+    
+    def test_list_users_success(
+        self,
+        client: TestClient,
+        test_admin: User,
+        admin_token: str,
+        db_session: Session
+    ) -> None:
+        """Test successful list users operation."""
+        response = client.get(
+            "/api/v1/users",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+        assert data["total"] >= 1  # At least the admin user
+        
+    def test_list_users_with_filters(
+        self,
+        client: TestClient,
+        test_organization: Organization,
+        test_department: Department,
+        admin_token: str,
+        db_session: Session
+    ) -> None:
+        """Test list users with organization and department filters."""
+        # Create test user with department
+        from tests.factories import UserFactory
+        user = UserFactory.create(
+            db_session,
+            department_id=test_department.id
+        )
+        
+        # Filter by organization
+        response = client.get(
+            f"/api/v1/users?organization_id={test_organization.id}",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        
+        # Filter by department
+        response = client.get(
+            f"/api/v1/users?department_id={test_department.id}",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert any(item["id"] == user.id for item in data["items"])
+        
+    def test_get_user_success(
+        self,
+        client: TestClient,
+        test_user: User,
+        admin_token: str
+    ) -> None:
+        """Test successful get user operation."""
+        response = client.get(
+            f"/api/v1/users/{test_user.id}",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == test_user.id
+        assert data["email"] == test_user.email
+        assert data["full_name"] == test_user.full_name
+        
+    def test_get_user_not_found(
+        self,
+        client: TestClient,
+        admin_token: str
+    ) -> None:
+        """Test get user with non-existent ID."""
+        response = client.get(
+            "/api/v1/users/99999",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 404
+        
+    def test_create_user_success(
+        self,
+        client: TestClient,
+        test_organization: Organization,
+        test_department: Department,
+        admin_token: str
+    ) -> None:
+        """Test successful create user operation."""
+        payload = {
+            "email": "newuser@example.com",
+            "password": "SecurePass123!",
+            "full_name": "New User",
+            "phone": "080-1234-5678",
+            "department_id": test_department.id,
+            "is_active": True
+        }
+        
+        response = client.post(
+            "/api/v1/users",
+            json=payload,
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert data["email"] == payload["email"]
+        assert data["full_name"] == payload["full_name"]
+        assert data["phone"] == payload["phone"]
+        assert data["department_id"] == payload["department_id"]
+        assert "id" in data
+        assert "hashed_password" not in data  # Should not expose password
+        
+    def test_create_user_duplicate_email(
+        self,
+        client: TestClient,
+        test_user: User,
+        admin_token: str
+    ) -> None:
+        """Test create user with duplicate email."""
+        payload = {
+            "email": test_user.email,  # Duplicate email
+            "password": "SecurePass123!",
+            "full_name": "Duplicate User",
+            "is_active": True
+        }
+        
+        response = client.post(
+            "/api/v1/users",
+            json=payload,
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 409
+        data = response.json()
+        assert "detail" in data
+        
+    def test_create_user_invalid_password(
+        self,
+        client: TestClient,
+        admin_token: str
+    ) -> None:
+        """Test create user with invalid password."""
+        payload = {
+            "email": "weakpass@example.com",
+            "password": "weak",  # Too short
+            "full_name": "Weak Password User",
+            "is_active": True
+        }
+        
+        response = client.post(
+            "/api/v1/users",
+            json=payload,
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 422
+        
+    def test_update_user_success(
+        self,
+        client: TestClient,
+        test_user: User,
+        admin_token: str
+    ) -> None:
+        """Test successful update user operation."""
+        payload = {
+            "full_name": "Updated Name",
+            "phone": "090-9876-5432"
+        }
+        
+        response = client.put(
+            f"/api/v1/users/{test_user.id}",
+            json=payload,
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["full_name"] == payload["full_name"]
+        assert data["phone"] == payload["phone"]
+        
+    def test_update_user_not_found(
+        self,
+        client: TestClient,
+        admin_token: str
+    ) -> None:
+        """Test update user with non-existent ID."""
+        payload = {"full_name": "Updated Name"}
+        
+        response = client.put(
+            "/api/v1/users/99999",
+            json=payload,
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 404
+        
+    def test_delete_user_success(
+        self,
+        client: TestClient,
+        db_session: Session,
+        admin_token: str
+    ) -> None:
+        """Test successful delete user operation."""
+        # Create a user to delete
+        from tests.factories import UserFactory
+        user = UserFactory.create(db_session)
+        
+        response = client.delete(
+            f"/api/v1/users/{user.id}",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["id"] == user.id
+        
+        # Verify user is soft deleted
+        db_session.refresh(user)
+        assert user.is_deleted is True
+        assert user.is_active is False
+        
+    def test_delete_user_not_found(
+        self,
+        client: TestClient,
+        admin_token: str
+    ) -> None:
+        """Test delete user with non-existent ID."""
+        response = client.delete(
+            "/api/v1/users/99999",
+            headers=create_auth_headers(admin_token)
+        )
+        
+        assert response.status_code == 404
+        
+    def test_user_self_access(
+        self,
+        client: TestClient,
+        test_user: User,
+        user_token: str
+    ) -> None:
+        """Test user can access their own data."""
+        response = client.get(
+            f"/api/v1/users/{test_user.id}",
+            headers=create_auth_headers(user_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == test_user.id
+        
+    def test_user_cannot_access_others(
+        self,
+        client: TestClient,
+        test_admin: User,
+        user_token: str
+    ) -> None:
+        """Test user cannot access other users' data."""
+        response = client.get(
+            f"/api/v1/users/{test_admin.id}",
+            headers=create_auth_headers(user_token)
+        )
+        
+        assert response.status_code == 403
+        
+    def test_unauthorized_access(
+        self,
+        client: TestClient
+    ) -> None:
+        """Test access without authentication."""
+        response = client.get("/api/v1/users")
+        assert response.status_code == 401
+        
+        response = client.get("/api/v1/users/1")
+        assert response.status_code == 401
+        
+        response = client.post("/api/v1/users", json={})
+        assert response.status_code == 401
+        
+        response = client.put("/api/v1/users/1", json={})
+        assert response.status_code == 401
+        
+        response = client.delete("/api/v1/users/1")
+        assert response.status_code == 401
+
+
+class TestUserPasswordManagement:
+    """Test cases for user password management."""
+    
+    def test_change_password_success(
+        self,
+        client: TestClient,
+        test_user: User,
+        user_token: str
+    ) -> None:
+        """Test successful password change."""
+        payload = {
+            "current_password": "TestPassword123!",
+            "new_password": "NewSecurePass456!"
+        }
+        
+        response = client.put(
+            f"/api/v1/users/{test_user.id}/password",
+            json=payload,
+            headers=create_auth_headers(user_token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Password changed successfully"
+        
+    def test_change_password_wrong_current(
+        self,
+        client: TestClient,
+        test_user: User,
+        user_token: str
+    ) -> None:
+        """Test password change with wrong current password."""
+        payload = {
+            "current_password": "WrongPassword123!",
+            "new_password": "NewSecurePass456!"
+        }
+        
+        response = client.put(
+            f"/api/v1/users/{test_user.id}/password",
+            json=payload,
+            headers=create_auth_headers(user_token)
+        )
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert "現在のパスワードが正しくありません" in data["detail"]
+        
+    def test_change_password_weak_new_password(
+        self,
+        client: TestClient,
+        test_user: User,
+        user_token: str
+    ) -> None:
+        """Test password change with weak new password."""
+        payload = {
+            "current_password": "TestPassword123!",
+            "new_password": "weak"
+        }
+        
+        response = client.put(
+            f"/api/v1/users/{test_user.id}/password",
+            json=payload,
+            headers=create_auth_headers(user_token)
+        )
+        
+        assert response.status_code == 422


### PR DESCRIPTION
## 概要
Issue #3 に対応し、基本的なユーザー管理APIを実装しました。
PR #8 の型エラーとコンフリクトを解決した新しい実装です。

## 実装内容

### 5つの基本API
- `GET /api/v1/users` - ユーザー一覧（ページネーション、検索、フィルタ対応）
- `GET /api/v1/users/{id}` - ユーザー詳細取得
- `POST /api/v1/users` - ユーザー作成（管理者のみ）
- `PUT /api/v1/users/{id}` - ユーザー更新
- `DELETE /api/v1/users/{id}` - ユーザー削除（ソフトデリート、管理者のみ）

### 追加機能
- `PUT /api/v1/users/{id}/password` - パスワード変更
- Userモデルにphone, department_idフィールドを追加
- UserBasicスキーマを使用
- 適切な権限チェック（自分自身へのアクセス、管理者権限）

## 技術的な詳細

### TDDアプローチ
- 実装前にテストを作成
- 17個のテストすべてが合格
- 成功ケース、エラーケース、権限チェックをカバー

### 型安全性
- 認証なしアクセスは401を返すよう修正
- 重複メソッド名を解決（create_basic_user, update_basic_user）
- SQLAlchemy 2.0スタイル（Mapped型）を維持

### 変更ファイル
- `/backend/app/api/v1/users.py` - CRUD エンドポイント追加
- `/backend/app/schemas/user.py` - UserUpdateにdepartment_id追加、UserResponse拡張
- `/backend/app/services/user.py` - シンプルなCRUDメソッド追加
- `/backend/tests/integration/api/v1/test_users.py` - 統合テスト追加
- `/backend/app/core/dependencies.py` - 認証エラーコード修正
- `/backend/app/schemas/error.py` - timestampフィールド削除

## テスト結果
```
======================= 17 passed, 28 warnings in 36.35s =======================
```

## 今後の課題
- より詳細な権限管理は別PRで実装予定
- mypy --strict の型エラーは既存コードの問題で、別途対応予定

## チェックリスト
- [x] テストが全て合格
- [x] TDDアプローチで実装
- [x] 既存のコードパターンに従う
- [x] ドキュメント更新は不要（API仕様書は自動生成）

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)