### PR TITLE
fix: Mermaidグラフの括弧によるレンダリングエラーを修正

### DIFF
--- a/docs/SDAD/【実践ガイド】既存プロジェクトのSDAD移行戦略.md
+++ b/docs/SDAD/【実践ガイド】既存プロジェクトのSDAD移行戦略.md
@@ -37,7 +37,7 @@ graph TD
 
     subgraph Phase4["Phase 4: 完全統合と最適化"]
         H --> I[SDADが<br>デフォルトプロセスに]
-        I --> J[継続的な<br>プロセス改善(Kaizen)]
+        I --> J[継続的な<br>プロセス改善 Kaizen]
     end
 ```
 


### PR DESCRIPTION
## 問題
前回の修正後もGitHub上でSDAD移行戦略ドキュメントのMermaidグラフが以下のエラーで表示されない：
```
Parse error on line 20:
...--> J[継続的な<br>プロセス改善(Kaizen)] end
-----------------------^
Expecting 'SQE', 'DOUBLECIRCLEEND', 'PE', '-)', 'STADIUMEND', 'SUBROUTINEEND', 'PIPE', 'CYLINDEREND', 'DIAMOND_STOP', 'TAGEND', 'TRAPEND', 'INVTRAPEND', 'UNICODE_TEXT', 'TEXT', 'TAGSTART', got 'PS'
```

## 原因
GitHubのMermaidパーサーが括弧`()`を特殊文字として解釈し、`(Kaizen)`の部分でパースエラーが発生していた。

## 修正内容
- `プロセス改善(Kaizen)` を `プロセス改善 Kaizen` に変更
- 括弧を削除することでパースエラーを回避

## テスト方法
1. GitHub上でファイルを開く
2. セクション3のMermaidグラフが正しくレンダリングされることを確認
3. エラーメッセージが表示されないことを確認

## 関連PR
- #642 (前回の修正)